### PR TITLE
We need sequence_prefix/number to avoid falsely made_sequence_gap

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
@@ -198,6 +198,20 @@ def fill_statement_line_fields(env):
     )
 
 
+def fill_missing_sequence_mixin_fields(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move
+        SET sequence_prefix = substring(
+                name, '^(.*?)(?:\\d{0,9})(?:\\D*?)$'),
+            sequence_number = CAST(COALESCE(NULLIF(substring(
+                name, '^(?:.*?)(\\d{0,9})(?:\\D*?)$'),''), '0') as int)
+        WHERE name IS NOT NULL and name <> '/'
+    """,
+    )
+
+
 def fill_account_move_made_sequence_gap(env):
     openupgrade.logged_query(
         env.cr,
@@ -265,4 +279,5 @@ def migrate(env, version):
             "account.action_account_unreconcile",
         ],
     )
+    fill_missing_sequence_mixin_fields(env)
     fill_account_move_made_sequence_gap(env)


### PR DESCRIPTION
It is due to our use of account_move_name_sequence in v15 we are missing these
SQL lifted from https://github.com/OCA/OpenUpgrade/pull/3626

Description of the issue/feature this PR addresses:
Sets sequence_prefix and sequence_number on account.move missing those

Current behavior before PR:
made_squence_gap is wrong, causing lines to be red

Desired behavior after PR is merged:
made_sequence_gap is correctly set in fill_account_move_made_sequence_gap




Addons:
openupgrade_scripts